### PR TITLE
Feat/248 wallet connect code failing to update connect button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"flowbite": "^1.8.1",
 				"micro-packed": "^0.3.2",
 				"sats-connect": "^0.5.0",
-				"sbtc-bridge-lib": "^1.1.1",
+				"sbtc-bridge-lib": "^1.1.2",
 				"sockjs": "^0.3.24",
 				"svelte-local-storage-store": "^0.5.0",
 				"svelte-qrcode": "^1.0.0",
@@ -3851,9 +3851,9 @@
 			}
 		},
 		"node_modules/sbtc-bridge-lib": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/sbtc-bridge-lib/-/sbtc-bridge-lib-1.1.1.tgz",
-			"integrity": "sha512-OPK2oM3U6+BzJY29YeXCFmucOrupa2Xk5C/0jV9TCANqJLicx8ZxvGHkMQAbDk5gJaqs6iKz3xJ7TxhcljmcNw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sbtc-bridge-lib/-/sbtc-bridge-lib-1.1.2.tgz",
+			"integrity": "sha512-BMUt5xvle1JRZxia0DWL2yyFBsl5ke7f9GHWsMzNpIHIQhjW6qqTf5s3ZWTutp2PF86F8Dh9QTpmLMbeA94Y/g==",
 			"dependencies": {
 				"@noble/secp256k1": "^2.0.0",
 				"@scure/base": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"flowbite": "^1.8.1",
 		"micro-packed": "^0.3.2",
 		"sats-connect": "^0.5.0",
-		"sbtc-bridge-lib": "^1.1.1",
+		"sbtc-bridge-lib": "^1.1.2",
 		"sockjs": "^0.3.24",
 		"svelte-local-storage-store": "^0.5.0",
 		"svelte-qrcode": "^1.0.0",

--- a/src/lib/bridge_api.ts
+++ b/src/lib/bridge_api.ts
@@ -113,6 +113,7 @@ export async function sendRawTransaction(tx: { hex: string; maxFeeRate: number|u
   return await extractResponse(response);
 }
 
+/**
 export async function fetchKeys() {
   const path = addNetSelector(CONFIG.VITE_BRIDGE_API + '/btc/tx/keys');
   const response = await fetchCatchErrors(path);
@@ -122,7 +123,7 @@ export async function fetchKeys() {
   const res = await extractResponse(response);
   return res;
 }
-
+ */
 export async function signAndBroadcast(wrappedPsbt:WrappedPSBT) {
   const path = addNetSelector(CONFIG.VITE_BRIDGE_API + '/btc/tx/signAndBroadcast');
   const response = await fetch(path, {

--- a/src/lib/bridge_api.ts
+++ b/src/lib/bridge_api.ts
@@ -4,7 +4,7 @@ import { checkAddressForNetwork } from 'sbtc-bridge-lib';
 
 let authHeader:any;
 
-export function setAuthorisation(auth:any) {
+export async function setAuthorisation(auth:any) {
   authHeader = auth
 }
 function headers() {

--- a/src/lib/components/common/DebugPeginInfo.svelte
+++ b/src/lib/components/common/DebugPeginInfo.svelte
@@ -37,7 +37,7 @@ $: decodedScript = () => {
     {#if peginRequest}
     <div class="col-2">Txid</div><div class="col-10">{peginRequest.btcTxid}</div>
     <div class="col-2">Stacks Address</div><div class="col-10">{peginRequest.uiPayload.principal}</div>
-    <div class="col-2">SBTC Wallet</div><div class="col-10">{getPegWalletAddressFromPublicKey(CONFIG.VITE_NETWORK, peginRequest.uiPayload.sbtcWalletPublicKey)}</div>
+    <div class="col-2">SBTC Wallet</div><div class="col-10">{getPegWalletAddressFromPublicKey(CONFIG.VITE_NETWORK, $sbtcConfig.sbtcContractData.sbtcWalletPublicKey)}</div>
     <div class="col-2">Pegin Status</div><div class="col-10">{peginRequest.status}</div>
     <div class="col-2">Script Hash</div><div class="col-10">{peginRequest.commitTxScript?.script}</div>
     <div class="col-2">Payment Type</div><div class="col-10">{peginRequest.commitTxScript?.paymentType}</div>

--- a/src/lib/components/dashboard/DepositDrop.svelte
+++ b/src/lib/components/dashboard/DepositDrop.svelte
@@ -35,7 +35,7 @@
 
       const conf:SbtcConfig = $sbtcConfig;
       sbtcConfig.update(() => conf);
-      peginRequest = getBridgeDepositOpDrop(CONFIG.VITE_NETWORK, $sbtcConfig.payloadDepositData, $sbtcConfig.keySets[CONFIG.VITE_NETWORK].stxAddress);
+      peginRequest = getBridgeDepositOpDrop(CONFIG.VITE_NETWORK, $sbtcConfig.sbtcContractData.sbtcWalletPublicKey, $sbtcConfig.payloadDepositData, $sbtcConfig.keySets[CONFIG.VITE_NETWORK].stxAddress);
       timeLineStatus = 2;
       componentKey++;
     } catch(err:any) {

--- a/src/lib/components/dashboard/Withdraw.svelte
+++ b/src/lib/components/dashboard/Withdraw.svelte
@@ -42,7 +42,7 @@
           console.log('message: ', message)
           console.log('sigData: ', sigData)
           if ($sbtcConfig.userSettings.useOpDrop) {
-            peginRequest = getBridgeWithdrawOpDrop(CONFIG.VITE_NETWORK, $sbtcConfig.payloadWithdrawData, $sbtcConfig.keySets[CONFIG.VITE_NETWORK].stxAddress);
+            peginRequest = getBridgeWithdrawOpDrop(CONFIG.VITE_NETWORK, $sbtcConfig.sbtcContractData.sbtcWalletPublicKey, $sbtcConfig.payloadWithdrawData, $sbtcConfig.keySets[CONFIG.VITE_NETWORK].stxAddress);
           } else {
             peginRequest = getBridgeWithdraw(CONFIG.VITE_NETWORK, $sbtcConfig.payloadWithdrawData, $sbtcConfig.keySets[CONFIG.VITE_NETWORK].stxAddress)
           }

--- a/src/lib/components/dashboard/dr/SignTransaction.svelte
+++ b/src/lib/components/dashboard/dr/SignTransaction.svelte
@@ -144,7 +144,7 @@ onMount(async () => {
   if (peginRequest.mode === 'op_drop') {
     transaction = buildDepositTransactionOpDrop(CONFIG.VITE_NETWORK, $sbtcConfig.payloadDepositData, $sbtcConfig.btcFeeRates, addressInfo.utxos, peginRequest.commitTxScript!.address!);
   } else {
-    transaction = buildDepositTransaction(CONFIG.VITE_NETWORK, $sbtcConfig.payloadDepositData, $sbtcConfig.btcFeeRates, addressInfo.utxos)
+    transaction = buildDepositTransaction(CONFIG.VITE_NETWORK, $sbtcConfig.sbtcContractData.sbtcWalletPublicKey, $sbtcConfig.payloadDepositData, $sbtcConfig.btcFeeRates, addressInfo.utxos)
   }
   if (transaction.inputsLength === 0) {
     errorReason = '<p>Unable to create a signable PSBT</p><p>Change the bitcoin address on the previous screen to your Bitcoin Core or Electrum wallet and follow the instructions here for signing and broadcasting the transaction.</p><p>Alternatively switch to OP_DROP in the settings menu to deposit using commit reveal.</p>'

--- a/src/lib/components/dashboard/wr/SignTransaction.svelte
+++ b/src/lib/components/dashboard/wr/SignTransaction.svelte
@@ -142,9 +142,9 @@ onMount(async () => {
   amount = $sbtcConfig.payloadWithdrawData.amountSats;
   if (peginRequest.requestType === 'withdrawal') {
       if (peginRequest.mode === 'op_drop') {
-        transaction = buildWithdrawTransactionOpDrop(CONFIG.VITE_NETWORK, $sbtcConfig.payloadWithdrawData, addressInfo.utxos, $sbtcConfig.btcFeeRates, $sbtcConfig.keySets[CONFIG.VITE_NETWORK].stxAddress);
+        transaction = buildWithdrawTransactionOpDrop(CONFIG.VITE_NETWORK, $sbtcConfig.sbtcContractData.sbtcWalletPublicKey, $sbtcConfig.payloadWithdrawData, addressInfo.utxos, $sbtcConfig.btcFeeRates, $sbtcConfig.keySets[CONFIG.VITE_NETWORK].stxAddress);
       } else {
-        transaction = buildWithdrawTransaction(CONFIG.VITE_NETWORK, $sbtcConfig.payloadWithdrawData, addressInfo.utxos, $sbtcConfig.btcFeeRates);
+        transaction = buildWithdrawTransaction(CONFIG.VITE_NETWORK, $sbtcConfig.sbtcContractData.sbtcWalletPublicKey, $sbtcConfig.payloadWithdrawData, addressInfo.utxos, $sbtcConfig.btcFeeRates);
       }
   }
   if (transaction.inputsLength === 0) {

--- a/src/lib/components/settings/Networks.svelte
+++ b/src/lib/components/settings/Networks.svelte
@@ -8,9 +8,28 @@
 	import { fetchSbtcBalance } from '$lib/stacks_connect'
 	import Banner from '$lib/components/shared/Banner.svelte';
 
+	let mode = import.meta.env.MODE
+    //if (!mode) mode = 'testnet'
+
+	const switchDevnet = async () => {
+		setConfig('devnet');
+		await fetchSbtcBalance($sbtcConfig, true);
+		sbtcConfig.update((conf:SbtcConfig) => {
+			return conf;
+		});
+		const url = new URL(location.href);
+		if (mode === 'simnet') {
+			url.searchParams.set('net', 'testnet');
+		} else {
+			url.searchParams.set('net', 'devnet');
+		}
+		location.assign(url.search);
+	}
+
 	const toggleNetwork = async () => {
-		let net = 'mainnet';
-		if ('mainnet' === CONFIG.VITE_NETWORK) net = 'testnet';
+		let net = CONFIG.VITE_NETWORK;
+		if (net === 'mainnet') net = 'testnet';
+		else net = 'mainnet'
 		setConfig(net);
 		await fetchSbtcBalance($sbtcConfig, true);
 		sbtcConfig.update((conf:SbtcConfig) => {
@@ -52,7 +71,12 @@
 {/if}
 
 <div class="mt-4">
-  <Button on:click={() => toggleNetwork()} class="block w-full md:w-auto md:inline-flex items-center gap-x-1.5 bg-primary-01 px-4 py-2 font-normal text-black rounded-lg border border-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500/50 shrink-0">
-  	Switch network
-  </Button>
-</div>
+	<Button on:click={() => toggleNetwork()} class="block w-full md:w-auto md:inline-flex items-center gap-x-1.5 bg-primary-01 px-4 py-2 font-normal text-black rounded-lg border border-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500/50 shrink-0">
+		Switch network
+	</Button>
+	{#if mode === 'development'}
+	<a on:click|preventDefault={() => switchDevnet()} href="/" class="text-gray-400 ms-10">
+		Switch to devnet
+	</a>
+	{/if}
+  </div>

--- a/src/lib/components/transactions/CommittedDeposit.svelte
+++ b/src/lib/components/transactions/CommittedDeposit.svelte
@@ -79,7 +79,7 @@ onMount(async () => {
 		}
 	}
 	addressInfoReveal = await fetchUtxoSet(peginRequest.uiPayload.bitcoinAddress)
-	addressInfoReclaim = await fetchUtxoSet(getPegWalletAddressFromPublicKey(CONFIG.VITE_NETWORK, peginRequest.uiPayload.sbtcWalletPublicKey)!)
+	addressInfoReclaim = await fetchUtxoSet(getPegWalletAddressFromPublicKey(CONFIG.VITE_NETWORK, $sbtcConfig.sbtcContractData.sbtcWalletPublicKey)!)
 	if (peginRequest.btcTxid) commitTransaction = await fetchTransaction(peginRequest.btcTxid);
 	peginRequest.originator = commitTransaction.vout[1].scriptPubKey.address
 	reclaimTx = buildRevealOrReclaimTransaction(network, 100, true, peginRequest, commitTransaction)

--- a/src/lib/components/transactions/TrRevealReclaim.svelte
+++ b/src/lib/components/transactions/TrRevealReclaim.svelte
@@ -64,7 +64,7 @@ onMount(() => {
   <div class="mt-4 col-12">Reveal Data</div>
   <div class="col-md-2 col-sm-12 text-info">Sbtc Address</div><div class="col-md-10 col-sm-12">{$sbtcConfig.sbtcContractData.sbtcWalletAddress}</div>
   {#if stacksData && $sbtcConfig.userSettings.debugMode}
-  <div class="col-md-2 col-sm-12 text-info">Reveal Pub Key</div><div class="col-md-10 col-sm-12">{peginRequest.uiPayload.sbtcWalletPublicKey}</div>
+  <div class="col-md-2 col-sm-12 text-info">Reveal Pub Key</div><div class="col-md-10 col-sm-12">{$sbtcConfig.sbtcContractData.sbtcWalletPublicKey}</div>
   {/if}
   <div class="mt-4 col-12 text-info"></div>
   {#if peginRequest.status < 3}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -46,14 +46,14 @@ const TESTNET_CONFIG = {
     VITE_ENVIRONMENT: 'staging',
     VITE_PUBLIC_APP_NAME: 'sBTC Bridge Testnet',
     VITE_PUBLIC_APP_VERSION: '1.0.0',
-    VITE_BRIDGE_WS: 'ws://bridge.stx.eco',
-    VITE_URI_BRIDGE: 'https://bridge.stx.eco',
+    VITE_BRIDGE_WS: 'ws://bridge.sbtc.tech',
+    VITE_URI_BRIDGE: 'https://bridge.sbtc.tech',
     VITE_URI_SIGN: 'https://sign.stx.eco',
     VITE_ORIGIN: 'https://sbtc.tech',
     VITE_NETWORK: 'testnet',
     VITE_SBTC_COORDINATOR: 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5',
-    VITE_BRIDGE_API: 'https://bridge.stx.eco/bridge-api/v1',
-    VITE_SIGNER_API: 'https://bridge.stx.eco/signer-api/v1',
+    VITE_BRIDGE_API: 'https://bridge.sbtc.tech/bridge-api/v1',
+    VITE_SIGNER_API: 'https://bridge.sbtc.tech/signer-api/v1',
     VITE_STACKS_API: 'https://api.testnet.hiro.so',
     VITE_STACKS_EXPLORER: 'https://explorer.hiro.so',
     VITE_BSTREAM_EXPLORER: 'https://mempool.space/testnet',
@@ -68,14 +68,14 @@ const MAINNET_CONFIG = {
     VITE_ENVIRONMENT: 'production',
     VITE_PUBLIC_APP_NAME: 'sBTC Bridge',
     VITE_PUBLIC_APP_VERSION: '1.0.0',
-    VITE_BRIDGE_WS: 'ws://bridge.stx.eco',
-    VITE_URI_BRIDGE: 'https://bridge.stx.eco',
+    VITE_BRIDGE_WS: 'ws://bridge.sbtc.tech',
+    VITE_URI_BRIDGE: 'https://bridge.sbtc.tech',
     VITE_URI_SIGN: 'https://sign.stx.eco',
     VITE_ORIGIN: 'https://sbtc.tech',
     VITE_NETWORK: 'mainnet',
     VITE_SBTC_COORDINATOR: 'ST3SPZXMPYVNHH3KF0RXNXVX1WVJ3QM1ZMD5FKWDN',
-    VITE_BRIDGE_API: 'https://bridge.stx.eco/bridge-api/v1',
-    VITE_SIGNER_API: 'https://bridge.stx.eco/signer-api/v1',
+    VITE_BRIDGE_API: 'https://bridge.sbtc.tech/bridge-api/v1',
+    VITE_SIGNER_API: 'https://bridge.sbtc.tech/signer-api/v1',
     VITE_STACKS_API: 'https://api.hiro.so',
     VITE_STACKS_EXPLORER: 'https://explorer.hiro.so',
     VITE_BSTREAM_EXPLORER: 'https://mempool.space',
@@ -88,20 +88,19 @@ const MAINNET_CONFIG = {
 
 export let CONFIG = MAINNET_CONFIG;
 
-export function setConfig(search:string) {
-    let mode = import.meta.env.MODE
-    if (!mode) mode = 'testnet'
+export function setConfig(network:string) {
+    //let mode = import.meta.env.MODE
+    //if (!mode) mode = 'testnet'
     //console.log('import.meta.env.MODE: ' + mode);
-	if (mode.startsWith('local-')) CONFIG = SIMNET_CONFIG;
-	else if (mode === 'development') CONFIG = DEVNET_CONFIG;
-	else if (search.indexOf('testnet') > -1) CONFIG = TESTNET_CONFIG;
-	else if (search.indexOf('simnet') > -1) CONFIG = SIMNET_CONFIG;
-	else if (search.indexOf('devnet') > -1) CONFIG = DEVNET_CONFIG;
+	if (network === 'devnet') CONFIG = DEVNET_CONFIG;
+	else if (network.indexOf('testnet') > -1) CONFIG = TESTNET_CONFIG;
+	else if (network.indexOf('simnet') > -1) CONFIG = SIMNET_CONFIG;
+	else if (network.indexOf('devnet') > -1) CONFIG = DEVNET_CONFIG;
 	else CONFIG = MAINNET_CONFIG
     if (import.meta.env.MODE === 'linode-staging') {
-        CONFIG.VITE_BRIDGE_API = 'https://bridge.stx.eco/bridge-api/v1'
+        CONFIG.VITE_BRIDGE_API = 'https://bridge.sbtc.tech/bridge-api/v1'
     }
-    if (mode === 'development') {
+    if (network === 'devnet') {
         CONFIG.VITE_BTC_SCHNORR_KEY_REVEAL = '93a7e5ecde5eccc4fd858dfcf7d92011eade103600de0e8122d6fc5ffedf962d';
         CONFIG.VITE_BTC_SCHNORR_KEY_RECLAIM = 'eb80b7f63eb74a215b6947b479e154a83cf429691dceab272c405b1614efb98c';
         CONFIG.VITE_BTC_SCHNORR_KEY_ORACLE = '0d7b49bc4864057b087108f81a57da7178cfbeb85a09c8957b64b9840e368b42';

--- a/src/lib/sbtc.ts
+++ b/src/lib/sbtc.ts
@@ -64,7 +64,6 @@ export const defaultSbtcConfig:SbtcConfig = {
   loggedIn: false,
   sigData: undefined,
   sbtcContractData: {} as SbtcContractDataType,
-  keys: {} as KeySet,
   userSettings: {
     useOpDrop: false,
     debugMode: false,
@@ -82,20 +81,27 @@ export const defaultSbtcConfig:SbtcConfig = {
         name: "Euro"
       },
       denomination: 'bitcoin'
-    }
+    },
+    peggingIn: false
   },
   keySets: {},
   revealFeeWithGas: 0,
   payloadDepositData: {
-    principal: undefined,
-    bitcoinAddress: undefined,
-    amountSats: 0
+    principal: '',
+    bitcoinAddress: '',
+    amountSats: 0,
+    sbtcWalletPublicKey: '',
+    reclaimPublicKey: '',
+    paymentPublicKey: ''
   },
   payloadWithdrawData: {
-    principal: undefined,
-    bitcoinAddress: undefined,
+    principal: '',
+    bitcoinAddress: '',
     signature: undefined,
-    amountSats: 0
+    amountSats: 0,
+    sbtcWalletPublicKey: '',
+    reclaimPublicKey: '',
+    paymentPublicKey: ''
   }
 }
 

--- a/src/lib/stacks_connect.ts
+++ b/src/lib/stacks_connect.ts
@@ -392,30 +392,6 @@ export async function initApplication(conf:SbtcConfig, fromLogin:boolean|undefin
 			conf.keySets = { 'mainnet': {} as AddressObject };
 		}
 	}
-	let keys;
-	const mode = import.meta.env.MODE
-	if (mode === 'development' || mode.startsWith('local') || !data.keys) {
-		try {
-			keys = {
-				deposits: {
-				  revealPubKey: hex.encode(schnorr.getPublicKey(hex.decode(CONFIG.VITE_BTC_SCHNORR_KEY_REVEAL))),
-				  reclaimPubKey: hex.encode(schnorr.getPublicKey(hex.decode(CONFIG.VITE_BTC_SCHNORR_KEY_RECLAIM)))
-				}
-			}
-		} catch(err) {
-			keys = {
-				deposits: {
-				  revealPubKey: undefined,
-				  reclaimPubKey: undefined
-				}
-			}
-		}
-	} else {
-		keys = data.keys;
-	}
-	keys.deposits.revealPubKey = data.sbtcContractData.sbtcWalletPublicKey
-	conf.keys = keys;
-
 	try {
 		conf.exchangeRates = await fetchExchangeRates();
 		if (!conf.exchangeRates) throw new Error('no exchnage rates')
@@ -439,6 +415,8 @@ export async function initApplication(conf:SbtcConfig, fromLogin:boolean|undefin
 			//
 		} 
 	}
+	conf.payloadDepositData.sbtcWalletPublicKey = conf.sbtcContractData.sbtcWalletPublicKey
+	conf.payloadWithdrawData.sbtcWalletPublicKey = conf.sbtcContractData.sbtcWalletPublicKey
 	if (!conf.keySets || !conf.keySets[CONFIG.VITE_NETWORK]) {
 		conf.keySets[CONFIG.VITE_NETWORK] = {} as AddressObject;
 	}
@@ -461,7 +439,7 @@ function doPayloadData(conf:SbtcConfig) {
 	}
 	const payloadDepositData:DepositPayloadUIType = {
 			sbtcWalletPublicKey: conf.sbtcContractData.sbtcWalletPublicKey,
-			reclaimPublicKey: conf.keys.deposits.reclaimPubKey,
+			reclaimPublicKey: conf.keySets[CONFIG.VITE_NETWORK].btcPubkeySegwit1 || '',
 			bitcoinAddress: conf.keySets[CONFIG.VITE_NETWORK].cardinal,
 			paymentPublicKey: conf.keySets[CONFIG.VITE_NETWORK].btcPubkeySegwit0 || '',
 			principal: prn,
@@ -478,7 +456,7 @@ function doPayloadData(conf:SbtcConfig) {
 	}
 	const payloadWithdrawData:WithdrawPayloadUIType = {
 			sbtcWalletPublicKey: conf.sbtcContractData.sbtcWalletPublicKey,
-			reclaimPublicKey: conf.keys.deposits.reclaimPubKey,
+			reclaimPublicKey: conf.keySets[CONFIG.VITE_NETWORK].btcPubkeySegwit1 || '',
 			bitcoinAddress: conf.keySets[CONFIG.VITE_NETWORK].cardinal,
 			paymentPublicKey: conf.keySets[CONFIG.VITE_NETWORK].btcPubkeySegwit0 || '',
 			principal: prn,

--- a/src/lib/stacks_connect.ts
+++ b/src/lib/stacks_connect.ts
@@ -272,6 +272,30 @@ export async function loginStacksJs(callback:any, conf:SbtcConfig) {
 	}
 }
 
+export async function loginStacks(callback:any) {
+	try {
+		const provider = getStacksProvider()
+		console.log('provider: ', provider)
+		if (!userSession.isUserSignedIn()) {
+			showConnect({
+				userSession,
+				appDetails: appDetails(),
+				onFinish: async () => {
+					callback(true);
+				},
+				onCancel: () => {
+					callback(false);
+				},
+			});
+		} else {
+			callback(true);
+		}
+	} catch (e) {
+		if (window) window.location.href = "https://wallet.hiro.so/wallet/install-web";
+		callback(false);
+	}
+}
+
 export function loginStacksFromHeader(document:any) {
 	const el = document.getElementById("connect-wallet")
 	if (el) return document.getElementById("connect-wallet").click();
@@ -418,8 +442,6 @@ export async function initApplication(conf:SbtcConfig, fromLogin:boolean|undefin
 	if (!conf.keySets || !conf.keySets[CONFIG.VITE_NETWORK]) {
 		conf.keySets[CONFIG.VITE_NETWORK] = {} as AddressObject;
 	}
-	const addr = btc.Address(net).decode('tb1perzpcdw7r4xsfk5kkvy9krxgrqp0f2gufm6ygauzcs7e27rs7lxqmkkrq4')
-	if (addr.type === 'tr') console.log('btc.Address(net).decode:' + hex.encode(addr.pubkey))
 	sbtcConfig.update(() => conf);
 
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -29,9 +29,12 @@
 			return;
 		}
 		const next = (nav.to?.url.pathname || '') + (nav.to?.url.search || '');
-			if (nav.to?.url.search.indexOf('testnet') === -1 && search.indexOf('net=testnet') > -1) {
+		if (nav.to?.url.search.indexOf('testnet') === -1 && search.indexOf('net=testnet') > -1) {
 			nav.cancel();
 			goto(next + '?net=testnet')
+		} else if (nav.to?.url.search.indexOf('devnet') === -1 && search.indexOf('net=devnet') > -1) {
+			nav.cancel();
+			goto(next + '?net=devnet')
 		}
 	})
 	afterNavigate((nav) => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -81,7 +81,6 @@
 			<slot></slot>
 		</div>
 		{/key}
-
 		<Footer />
 	</div>
 {/if}

--- a/src/types/sbtc_config.ts
+++ b/src/types/sbtc_config.ts
@@ -14,7 +14,6 @@ export type SbtcConfig = {
   peginRequest?:BridgeTransactionType;
   userSettings:SbtcUserSettingI;
   sbtcContractData: SbtcContractDataType;
-  keys: KeySet;
   revealFeeWithGas: number;
   payloadDepositData: DepositPayloadUIType;
   payloadWithdrawData: WithdrawPayloadUIType;


### PR DESCRIPTION
## Description

1. Bug Fix: Simplified the way the sbtc-wallet-public-key is handled and passed around.
2. Removed the dependence on reveal and reclaim public keys - these were custodial versions of the sbtc wallet public key used to unblock development work in early stages of project. 

## Fix

The wallet connect click handler was failing to fire due to an earlier exception related to the wallets public key now being defined. This only happened in a certain context and had an easy fix which involved refactoring the the way the key was passed from the front to back end service.

