### PR TITLE
Simple internal cache strategy for stateless info

### DIFF
--- a/src/lib/components/dashboard/dr/SignTransaction.svelte
+++ b/src/lib/components/dashboard/dr/SignTransaction.svelte
@@ -126,11 +126,11 @@ const updateBridgeTransaction = async (txid:string) => {
 let broadcasted:boolean;
 const broadcast = async (psbtHex:string) => {
   try {
-      const result:any = await broadcastTransaction(psbtHex)
+      const txid:string = await broadcastTransaction(psbtHex)
       if (peginRequest.mode === 'op_return') {
         peginRequest.status = 5;
       }
-      peginRequest.btcTxid = (result.hash) ? result.hash : result.txid;
+      peginRequest.btcTxid = txid;
       await saveBridgeTransaction(peginRequest);
       broadcasted = true;
   } catch (err:any) {

--- a/src/lib/components/dashboard/wr/SignTransaction.svelte
+++ b/src/lib/components/dashboard/wr/SignTransaction.svelte
@@ -125,11 +125,11 @@ const updateBridgeTransaction = async (txid:string) => {
 let broadcasted:boolean;
 const broadcast = async (psbtHex:string) => {
   try {
-      const result:any = await broadcastTransaction(psbtHex)
+      const txid:string = await broadcastTransaction(psbtHex)
       if (peginRequest.mode === 'op_return') {
         peginRequest.status = 5;
       }
-      peginRequest.btcTxid = (result.hash) ? result.hash : result.txid;
+      peginRequest.btcTxid = txid;
       await saveBridgeTransaction(peginRequest);
       broadcasted = true;
   } catch (err:any) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -42,6 +42,28 @@ const DEVNET_CONFIG = {
     VITE_BTC_SCHNORR_KEY_ORACLE: 'secret',
 }
 
+const DEV_TESTNET_CONFIG = {
+    VITE_ENVIRONMENT: 'devnet',
+    VITE_PUBLIC_APP_NAME: 'sBTC Bridge Devnet',
+    VITE_PUBLIC_APP_VERSION: '1.0.0',
+    VITE_URI_BRIDGE: 'http://localhost:8080',
+    VITE_URI_SIGN: 'http://localhost:8081',
+    VITE_ORIGIN: 'https://sbtc.tech',
+    VITE_NETWORK: 'testnet',
+    VITE_SBTC_COORDINATOR: 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5',
+    VITE_BRIDGE_WS: 'ws://localhost:3010',
+    VITE_BRIDGE_API: 'http://localhost:3010/bridge-api/v1',
+    VITE_SIGNER_API: 'http://localhost:3010/signer-api/v1',
+    VITE_STACKS_API: 'https://api.testnet.hiro.so',
+    VITE_STACKS_EXPLORER: 'https://explorer.hiro.so',
+    VITE_BSTREAM_EXPLORER: 'https://mempool.space/testnet',
+    VITE_MEMPOOL_EXPLORER: 'https://mempool.space/testnet/api',
+    VITE_BLOCKCYPHER_EXPLORER: 'https://api.blockcypher.com/v1/btc/test3',
+    VITE_BTC_SCHNORR_KEY_REVEAL: 'secret',
+    VITE_BTC_SCHNORR_KEY_RECLAIM: 'secret',
+    VITE_BTC_SCHNORR_KEY_ORACLE: 'secret',
+}
+
 const TESTNET_CONFIG = {
     VITE_ENVIRONMENT: 'staging',
     VITE_PUBLIC_APP_NAME: 'sBTC Bridge Testnet',
@@ -89,7 +111,13 @@ const MAINNET_CONFIG = {
 export let CONFIG = MAINNET_CONFIG;
 
 export function setConfig(network:string) {
-    //let mode = import.meta.env.MODE
+    if (network.indexOf('=')) network = network.split('=')[1]
+    const mode = import.meta.env.MODE
+    if (mode === 'development') {
+        if (network === 'testnet') CONFIG = DEV_TESTNET_CONFIG;
+        else CONFIG = DEVNET_CONFIG;
+        return;
+    }
     //if (!mode) mode = 'testnet'
     //console.log('import.meta.env.MODE: ' + mode);
 	if (network === 'devnet') CONFIG = DEVNET_CONFIG;

--- a/src/lib/header/Header.svelte
+++ b/src/lib/header/Header.svelte
@@ -103,7 +103,7 @@
 		{#if coordinator}
 			<NavLi nonActiveClass={getNavActiveClass('/admin')} href="/admin">Admin</NavLi>
 		{/if}
-		{#if !$sbtcConfig.userSettings.debugMode}
+		{#if $sbtcConfig.userSettings.debugMode}
 			<NavLi nonActiveClass={getNavActiveClass('/proofs')} href="/proofs">Tx Check</NavLi>
 		{/if}
 

--- a/src/lib/stacks_connect.ts
+++ b/src/lib/stacks_connect.ts
@@ -12,8 +12,6 @@ import { defaultSbtcConfig } from '$lib/sbtc';
 import { fetchExchangeRates } from "$lib/bridge_api"
 import { hex } from '@scure/base';
 import type { DepositPayloadUIType, ExchangeRate, WithdrawPayloadUIType } from 'sbtc-bridge-lib';
-import { schnorr } from '@noble/curves/secp256k1';
-import * as btc from '@scure/btc-signer';
 import { AddressPurposes, getAddress } from 'sats-connect'
 import type { GetAddressOptions } from 'sats-connect'
 import { getStacksAddressFromPubkey } from 'sbtc-bridge-lib/dist/payload_utils';
@@ -364,11 +362,6 @@ export function verifySBTCAmount(amount:number, balance:number, fee:number) {
 }
   
 export async function initApplication(conf:SbtcConfig, fromLogin:boolean|undefined) {
-	const net = (CONFIG.VITE_NETWORK === 'testnet') ? btc.TEST_NETWORK : btc.NETWORK;
-	let privKey = btc.p2wpkh(hex.decode('03a4572841fec581e7e5370cad34b04387389e1fdf06b1814534e7203c761802da'), net);
-	console.log(privKey)
-	privKey = btc.p2tr(hex.decode('a4572841fec581e7e5370cad34b04387389e1fdf06b1814534e7203c761802da'), undefined, net);
-	console.log(privKey)
 	if (!conf) conf = defaultSbtcConfig as SbtcConfig
 	let data = {} as any;
 	try {
@@ -382,7 +375,7 @@ export async function initApplication(conf:SbtcConfig, fromLogin:boolean|undefin
 	} catch (err) {
 		data = {
 			sbtcContractData: {} as SbtcContractDataType
-		} as any;
+		} as any; 
 	}
 	//conf.sbtcContractData = data.sbtcContractData;
 	if (!conf.keySets) {
@@ -393,7 +386,7 @@ export async function initApplication(conf:SbtcConfig, fromLogin:boolean|undefin
 		}
 	}
 	try {
-		conf.exchangeRates = await fetchExchangeRates();
+		conf.exchangeRates = data.rates;
 		if (!conf.exchangeRates) throw new Error('no exchnage rates')
 		const currency = conf.userSettings.currency?.myFiatCurrency?.currency;
 		const rateNow = conf.exchangeRates.find((o:any) => o.currency === currency)


### PR DESCRIPTION
PR creates a simple cache for a couple of stateless endpoints which provide the UI with initialisation data.

Example:
/ui-init - provides sbtc contract data, info about exchange rates and fee estimates return a cached object

Scheduled job initUiCacheJob runs every three minutes and refreshes the cached object